### PR TITLE
Make NetworkLoader more resilient.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## master
+
+- `Premailer::Rails::CSSLoaders::NetworkLoader` is more resilient and works even
+  if the Rails asset host is set without a URI scheme. (panthomakos)
+
 ## v1.8.0
 
 - `ActionMailer` interceptors are registered after Rails initialization and no

--- a/lib/premailer/rails/css_loaders/network_loader.rb
+++ b/lib/premailer/rails/css_loaders/network_loader.rb
@@ -11,16 +11,20 @@ class Premailer
 
         def uri_for_url(url)
           uri = URI(url)
+          return uri if valid_uri?(uri)
 
-          if not valid_uri?(uri) and defined?(::Rails)
-            scheme, host =
-              asset_host.split(%r{:?//})
-            scheme = 'http' if scheme.blank?
-            uri.scheme ||= scheme
-            uri.host ||= host
-          end
+          return nil unless asset_host.present?
+          URI("#{scheme}://#{host}#{url}")
+        end
 
-          uri if valid_uri?(uri)
+        private
+
+        def scheme
+          asset_host.start_with?('https://') ? 'https' : 'http'
+        end
+
+        def host
+          asset_host.sub(/^http[s]?:\/\//,'')
         end
 
         def valid_uri?(uri)

--- a/spec/unit/css_loaders/network_loader_spec.rb
+++ b/spec/unit/css_loaders/network_loader_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe Premailer::Rails::CSSLoaders::NetworkLoader do
+  describe '#uri_for_url' do
+    let(:path){ '/assets/foo.css' }
+    subject{ described_class.uri_for_url(path) }
+
+    context 'with an asset host' do
+      let(:host){ 'example.com' }
+      let(:config){ double(action_controller: double(asset_host: host)) }
+
+      before{ allow(Rails).to receive(:configuration).and_return(config) }
+
+      it 'creates a URI with the asset host' do
+        expect(subject.host).to eq(host)
+      end
+
+      it 'creates a URI with the proper scheme' do
+        expect(subject.scheme).to eq('http')
+      end
+
+      it 'infers the scheme from the asset host if present' do
+        allow(config.action_controller).to receive(:asset_host){ "https://#{host}" }
+        expect(subject.host).to eq(host)
+        expect(subject.scheme).to eq('https')
+      end
+
+      it 'creates a URI with the proper request uri' do
+        expect(subject.request_uri).to eq(path)
+      end
+    end
+
+    context 'without an asset host' do
+      let(:config){ double(action_controller: double(asset_host: nil)) }
+
+      before{ allow(Rails).to receive(:configuration).and_return(config) }
+
+      it{ is_expected.to be(nil) }
+    end
+
+    context 'already valid URL' do
+      let(:path){ 'http://example2.com/image.jpg' }
+
+      it 'creates a URI with the proper host' do
+        expect(subject.host).to eq('example2.com')
+      end
+
+      it 'creates a URI with the proper scheme' do
+        expect(subject.scheme).to eq('http')
+      end
+
+      it 'creates a URI with the proper request uri' do
+        expect(subject.request_uri).to eq('/image.jpg')
+      end
+    end
+  end
+end


### PR DESCRIPTION
If the Rails asset host is set without a scheme (which is the
recommended way to set an asset host so that it works both with HTTP and
HTTPS pages) the `NetworkLoader` will fail because it requires a scheme to
be present. This change allows the `NetworkLoader` to work with asset
hosts that do and don't include the http scheme.

This change also removes the dynamic setting of `scheme` and `host` on
URI which does not work (the GET call still fails since `request_uri` is
undefined).

I've included tests to make sure the `NetworkLoader` now works with the
asset host set (with and without a scheme) and does not cause exceptions.
